### PR TITLE
remove a /

### DIFF
--- a/root/etc/cont-init.d/30-keygen
+++ b/root/etc/cont-init.d/30-keygen
@@ -1,5 +1,5 @@
 #!/usr/bin/with-contenv bash
-SUBJECT="//C=US/ST=CA/L=Carlsbad/O=Linuxserver.io/OU=LSIO Server/CN=*"
+SUBJECT="/C=US/ST=CA/L=Carlsbad/O=Linuxserver.io/OU=LSIO Server/CN=*"
 if [[ -f /config/keys/cert.key && -f /config/keys/cert.crt ]]; then
 echo "using keys found in /config/keys"
 else


### PR DESCRIPTION
because it was passing /C as argument which was giving an error like : Subject Attribute /C has no known NID, skipped
related to : https://github.com/linuxserver/docker-baseimage-alpine-nginx/pull/34
